### PR TITLE
TokenFactory bindings #NTRN-431

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,12 +44,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22add0f9b2a5416df98c1d0248a8d8eedb882c38fbf0c5052b64eebe865df6d"
+checksum = "75836a10cb9654c54e77ee56da94d592923092a10b369cdb0dbd56acefc16340"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -143,18 +137,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e64f710a18ef90d0a632cf27842e98ffc2d005a38a6f76c12fd0bc03bc1a2d"
+checksum = "1c9f7f0e51bfc7295f7b2664fe8513c966428642aa765dad8a74acdab5e0c773"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5ad2e23a971b9e4cd57b20cee3e2e79c33799bed4b128e473aca3702bfe5dd"
+checksum = "3e9e92cdce475a91659d0dc4d17836a484fc534e80e787281aa4adde4cb1798b"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -165,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2926d159a9bb1a716a592b40280f1663f2491a9de3b6da77c0933cee2a2655b8"
+checksum = "69681bac3dbeb0b00990279e3ed39e3d4406b29f538b16b712f6771322a45048"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
@@ -176,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.3"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fee88ff5bf7bef55bd37ac0619974701b99bf6bd4b16cf56ee8810718abd71"
+checksum = "a49b85345e811c8e80ec55d0d091e4fcb4f00f97ab058f9be5f614c444a730cb"
 dependencies = [
  "base64 0.13.1",
  "cosmwasm-crypto",
@@ -188,7 +182,7 @@ dependencies = [
  "hex",
  "schemars",
  "serde",
- "serde-json-wasm 0.5.0",
+ "serde-json-wasm 0.5.1",
  "sha2 0.10.6",
  "thiserror",
  "uint",
@@ -273,7 +267,7 @@ checksum = "c2eb84554bbfa6b66736abcd6a9bfdf237ee0ecb83910f746dff7f799093c80a"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
- "cw-storage-plus 1.0.1",
+ "cw-storage-plus",
  "cw-utils",
  "derivative",
  "itertools",
@@ -282,28 +276,6 @@ dependencies = [
  "schemars",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8b264257c4f44c49b7ce09377af63aa040768ecd3fd7bdd2d48a09323a1e90"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw-storage-plus"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6cf70ef7686e2da9ad7b067c5942cd3e88dd9453f7af42f54557f8af300fb0"
-dependencies = [
- "cosmwasm-std",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -325,24 +297,11 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2",
  "schemars",
  "semver",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "cw2"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5abb8ecea72e09afff830252963cb60faf945ce6cef2c20a43814516082653da"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.15.1",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -353,7 +312,7 @@ checksum = "8fb70cee2cf0b4a8ff7253e6bc6647107905e8eb37208f87d54f67810faa62f8"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.0.1",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
@@ -423,7 +382,7 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 0.15.1",
+ "cw2",
  "schemars",
  "serde",
 ]
@@ -562,8 +521,8 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "cw2 0.15.1",
+ "cw-storage-plus",
+ "cw2",
  "neutron-sdk",
  "protobuf",
  "schemars",
@@ -610,8 +569,8 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "cw2 0.15.1",
+ "cw-storage-plus",
+ "cw2",
  "neutron-sdk",
  "protobuf",
  "schemars",
@@ -623,16 +582,14 @@ dependencies = [
 name = "neutron-price-feed-mock"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.0",
  "cosmos-sdk-proto 0.16.0",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-band",
  "cw-multi-test",
- "cw-storage-plus 1.0.1",
- "cw2 1.0.1",
- "neutron-sdk",
+ "cw-storage-plus",
+ "cw2",
  "obi",
  "owasm-kit",
  "prost 0.11.8",
@@ -647,16 +604,16 @@ dependencies = [
 
 [[package]]
 name = "neutron-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a57cb451a16a676ecbbb1bb1e0e2e9bc9989834d82c6b16eebc24d9ed97cf"
+checksum = "487305afc06808aabe5b90684bc238c93fb8872a275edf6db4ea24b102eb9a8e"
 dependencies = [
  "base64 0.20.0",
  "bech32",
  "cosmos-sdk-proto 0.16.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.0.1",
+ "cw-storage-plus",
  "prost 0.11.8",
  "protobuf",
  "schemars",
@@ -674,8 +631,8 @@ dependencies = [
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "cw2 0.15.1",
+ "cw-storage-plus",
+ "cw2",
  "neutron-sdk",
  "prost 0.11.8",
  "schemars",
@@ -687,13 +644,12 @@ dependencies = [
 name = "neutron_interchain_txs"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.1",
  "bech32",
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.0.1",
- "cw2 0.15.1",
+ "cw-storage-plus",
+ "cw2",
  "neutron-sdk",
  "prost 0.11.8",
  "prost-types 0.11.8",
@@ -708,13 +664,12 @@ dependencies = [
 name = "neutron_validators_test"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.1",
  "bech32",
  "cosmos-sdk-proto 0.14.0",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.14.0",
- "cw2 0.15.1",
+ "cw-storage-plus",
+ "cw2",
  "neutron-sdk",
  "prost 0.11.8",
  "prost-types 0.10.1",
@@ -1043,7 +998,7 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 0.15.1",
+ "cw2",
  "neutron-sdk",
  "schemars",
  "serde",
@@ -1118,9 +1073,9 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
@@ -1136,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15bee9b04dd165c3f4e142628982ddde884c2022a89e8ddf99c4829bf2c3a58"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -1154,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote 1.0.26",
@@ -1363,6 +1318,17 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tokenfactory"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "neutron-sdk",
+ "schemars",
+ "serde",
+]
 
 [[package]]
 name = "typenum"

--- a/contracts/echo/Cargo.toml
+++ b/contracts/echo/Cargo.toml
@@ -33,8 +33,8 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking"] }
-cw2 = "0.15.1"
+cosmwasm-std = "1.2.5"
+cw2 = "1.0.1"
 schemars = "0.8.10"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 

--- a/contracts/msg_receiver/Cargo.toml
+++ b/contracts/msg_receiver/Cargo.toml
@@ -33,13 +33,13 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking", "stargate"] }
-cw2 = "0.15.1"
+cosmwasm-std = "1.2.5"
+cw2 = "1.0.1"
 schemars = "0.8.10"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "0.4.1" }
-neutron-sdk = { package = "neutron-sdk",  default-features = false, version = "0.4.0" }
-cw-storage-plus = { version = "0.14.0", features = ["iterator"]}
+neutron-sdk = "0.5.0"
+cw-storage-plus = "1.0.1"
 protobuf = { version = "3.2.0", features = ["with-bytes"] }
 
 [dev-dependencies]

--- a/contracts/neutron_interchain_queries/Cargo.toml
+++ b/contracts/neutron_interchain_queries/Cargo.toml
@@ -32,14 +32,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking"] }
-cw2 = "0.15.1"
+cosmwasm-std = "1.2.5"
+cw2 = "1.0.1"
 schemars = "0.8.10"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-neutron-sdk = { package = "neutron-sdk", default-features = false, version = "0.4.0" }
+neutron-sdk = "0.5.0"
 base64 = "0.13.0"
 cosmos-sdk-proto = { version = "0.14.0", default-features = false }
-cw-storage-plus = { version = "0.14.0", features = ["iterator"]}
+cw-storage-plus = "1.0.1"
 prost = "0.11"
 serde-json-wasm = "0.4.1"
 

--- a/contracts/neutron_interchain_queries/src/integration_tests_mock_handlers.rs
+++ b/contracts/neutron_interchain_queries/src/integration_tests_mock_handlers.rs
@@ -1,15 +1,16 @@
 use crate::state::{IntegrationTestsQueryMock, INTEGRATION_TESTS_QUERY_MOCK};
 use cosmwasm_std::{DepsMut, Response};
-use neutron_sdk::bindings::msg::NeutronMsg;
-use neutron_sdk::bindings::query::InterchainQueries;
-use neutron_sdk::NeutronResult;
+use neutron_sdk::{
+    bindings::{msg::NeutronMsg, query::NeutronQuery},
+    NeutronResult,
+};
 
-pub fn set_query_mock(deps: DepsMut<InterchainQueries>) -> NeutronResult<Response<NeutronMsg>> {
+pub fn set_query_mock(deps: DepsMut<NeutronQuery>) -> NeutronResult<Response<NeutronMsg>> {
     INTEGRATION_TESTS_QUERY_MOCK.save(deps.storage, &IntegrationTestsQueryMock::Enabled)?;
     Ok(Response::default())
 }
 
-pub fn unset_query_mock(deps: DepsMut<InterchainQueries>) -> NeutronResult<Response<NeutronMsg>> {
+pub fn unset_query_mock(deps: DepsMut<NeutronQuery>) -> NeutronResult<Response<NeutronMsg>> {
     INTEGRATION_TESTS_QUERY_MOCK.save(deps.storage, &IntegrationTestsQueryMock::Disabled)?;
     Ok(Response::default())
 }

--- a/contracts/neutron_interchain_queries/src/testing/mock_querier.rs
+++ b/contracts/neutron_interchain_queries/src/testing/mock_querier.rs
@@ -23,7 +23,7 @@ use cosmwasm_std::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use neutron_sdk::bindings::query::InterchainQueries;
+use neutron_sdk::bindings::query::NeutronQuery;
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
 
@@ -36,7 +36,7 @@ impl CustomQuery for CustomQueryWrapper {}
 
 pub fn mock_dependencies(
     contract_balance: &[Coin],
-) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier, InterchainQueries> {
+) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier, NeutronQuery> {
     let contract_addr = MOCK_CONTRACT_ADDR;
     let custom_querier: WasmMockQuerier =
         WasmMockQuerier::new(MockQuerier::new(&[(contract_addr, contract_balance)]));
@@ -50,14 +50,14 @@ pub fn mock_dependencies(
 }
 
 pub struct WasmMockQuerier {
-    base: MockQuerier<InterchainQueries>,
+    base: MockQuerier<NeutronQuery>,
     query_reponses: HashMap<u64, Binary>,
     registred_queries: HashMap<u64, Binary>,
 }
 
 impl Querier for WasmMockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        let request: QueryRequest<InterchainQueries> = match from_slice(bin_request) {
+        let request: QueryRequest<NeutronQuery> = match from_slice(bin_request) {
             Ok(v) => v,
             Err(e) => {
                 return QuerierResult::Err(SystemError::InvalidRequest {
@@ -71,26 +71,26 @@ impl Querier for WasmMockQuerier {
 }
 
 impl WasmMockQuerier {
-    pub fn handle_query(&self, request: &QueryRequest<InterchainQueries>) -> QuerierResult {
+    pub fn handle_query(&self, request: &QueryRequest<NeutronQuery>) -> QuerierResult {
         match &request {
-            QueryRequest::Custom(InterchainQueries::InterchainQueryResult { query_id }) => {
+            QueryRequest::Custom(NeutronQuery::InterchainQueryResult { query_id }) => {
                 SystemResult::Ok(ContractResult::Ok(
                     (*self.query_reponses.get(query_id).unwrap()).clone(),
                 ))
             }
-            QueryRequest::Custom(InterchainQueries::RegisteredInterchainQuery { query_id }) => {
+            QueryRequest::Custom(NeutronQuery::RegisteredInterchainQuery { query_id }) => {
                 SystemResult::Ok(ContractResult::Ok(
                     (*self.registred_queries.get(query_id).unwrap()).clone(),
                 ))
             }
-            QueryRequest::Custom(InterchainQueries::RegisteredInterchainQueries {
+            QueryRequest::Custom(NeutronQuery::RegisteredInterchainQueries {
                 owners: _owners,
                 connection_id: _connection_id,
                 pagination: _pagination,
             }) => {
                 todo!()
             }
-            QueryRequest::Custom(InterchainQueries::InterchainAccountAddress { .. }) => {
+            QueryRequest::Custom(NeutronQuery::InterchainAccountAddress { .. }) => {
                 todo!()
             }
             _ => self.base.handle_query(request),
@@ -125,7 +125,7 @@ pub struct TokenQuerier {
 }
 
 impl WasmMockQuerier {
-    pub fn new(base: MockQuerier<InterchainQueries>) -> Self {
+    pub fn new(base: MockQuerier<NeutronQuery>) -> Self {
         WasmMockQuerier {
             base,
             query_reponses: HashMap::new(),

--- a/contracts/neutron_interchain_queries/src/testing/tests.rs
+++ b/contracts/neutron_interchain_queries/src/testing/tests.rs
@@ -29,28 +29,31 @@ use cosmwasm_std::{
     from_binary, to_binary, Addr, Binary, Coin, Decimal, Delegation, Env, MessageInfo, OwnedDeps,
     StdError, Uint128,
 };
-use neutron_sdk::bindings::query::{
-    InterchainQueries, QueryRegisteredQueryResponse, QueryRegisteredQueryResultResponse,
-};
-use neutron_sdk::bindings::types::{
-    decode_hex, Height, InterchainQueryResult, KVKey, KVKeys, RegisteredQuery, StorageValue,
-};
-use neutron_sdk::interchain_queries::helpers::{
-    create_account_denom_balance_key, create_fee_pool_key, create_gov_proposal_key,
-    create_total_denom_key, create_validator_key, decode_and_convert,
-};
-use neutron_sdk::interchain_queries::types::{
-    Balances, FeePool, GovernmentProposal, Proposal, QueryType, StakingValidator, TallyResult,
-    TotalSupply, TransactionFilterItem, TransactionFilterOp, TransactionFilterValue, Validator,
-    RECIPIENT_FIELD,
+use neutron_sdk::{
+    bindings::{
+        query::{NeutronQuery, QueryRegisteredQueryResponse, QueryRegisteredQueryResultResponse},
+        types::{
+            decode_hex, Height, InterchainQueryResult, KVKey, KVKeys, RegisteredQuery, StorageValue,
+        },
+    },
+    interchain_queries::{
+        helpers::{
+            create_account_denom_balance_key, create_fee_pool_key, create_gov_proposal_key,
+            create_total_denom_key, create_validator_key, decode_and_convert,
+        },
+        queries::{
+            BalanceResponse, DelegatorDelegationsResponse, FeePoolResponse, ProposalResponse,
+            TotalSupplyResponse, ValidatorResponse,
+        },
+        types::{
+            Balances, FeePool, GovernmentProposal, Proposal, QueryType, StakingValidator,
+            TallyResult, TotalSupply, TransactionFilterItem, TransactionFilterOp,
+            TransactionFilterValue, Validator, RECIPIENT_FIELD,
+        },
+    },
+    NeutronError,
 };
 use prost::Message as ProstMessage;
-
-use neutron_sdk::interchain_queries::queries::{
-    BalanceResponse, DelegatorDelegationsResponse, FeePoolResponse, ProposalResponse,
-    TotalSupplyResponse, ValidatorResponse,
-};
-use neutron_sdk::NeutronError;
 use schemars::_serde_json::to_string;
 
 enum QueryParam {
@@ -223,7 +226,7 @@ fn build_interchain_query_balance_response(addr: Addr, denom: String, amount: St
 
 // registers an interchain query
 fn register_query(
-    deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier, InterchainQueries>,
+    deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier, NeutronQuery>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,

--- a/contracts/neutron_interchain_txs/Cargo.toml
+++ b/contracts/neutron_interchain_txs/Cargo.toml
@@ -32,15 +32,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking"] }
-cw2 = "0.15.1"
+cosmwasm-std = "1.2.5"
+cw2 = "1.0.1"
 schemars = "0.8.10"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "0.4.1" }
-cw-storage-plus = { version = "1.0.1", features = ["iterator"]}
+cw-storage-plus = "1.0.1"
 cosmos-sdk-proto = { version = "0.14.0", default-features = false }
-neutron-sdk = { package = "neutron-sdk", default-features = false, version = "0.4.0" }
-base64 = "0.13.0"
+neutron-sdk = "0.5.0"
 protobuf = { version = "3.2.0", features = ["with-bytes"] }
 prost = "0.11"
 prost-types = "0.11"

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -29,14 +29,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::integration_tests_mock_handlers::{set_sudo_failure_mock, unset_sudo_failure_mock};
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use neutron_sdk::bindings::msg::{IbcFee, MsgSubmitTxResponse, NeutronMsg};
-use neutron_sdk::bindings::query::{InterchainQueries, QueryInterchainAccountAddressResponse};
-use neutron_sdk::bindings::types::ProtobufAny;
-use neutron_sdk::interchain_txs::helpers::{
-    decode_acknowledgement_response, decode_message_response, get_port_id,
+use neutron_sdk::{
+    bindings::{
+        msg::{IbcFee, MsgSubmitTxResponse, NeutronMsg},
+        query::{NeutronQuery, QueryInterchainAccountAddressResponse},
+        types::ProtobufAny,
+    },
+    interchain_txs::helpers::{
+        decode_acknowledgement_response, decode_message_response, get_port_id,
+    },
+    sudo::msg::{RequestPacket, SudoMsg},
+    NeutronResult,
 };
-use neutron_sdk::sudo::msg::{RequestPacket, SudoMsg};
-use neutron_sdk::NeutronResult;
 
 use crate::storage::{
     add_error_to_queue, read_errors_from_queue, read_reply_payload, read_sudo_payload,
@@ -134,7 +138,7 @@ pub fn execute(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
+pub fn query(deps: Deps<NeutronQuery>, env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
     match msg {
         QueryMsg::InterchainAccountAddress {
             interchain_account_id,
@@ -152,12 +156,12 @@ pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> NeutronR
 }
 
 pub fn query_interchain_address(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
     connection_id: String,
 ) -> NeutronResult<Binary> {
-    let query = InterchainQueries::InterchainAccountAddress {
+    let query = NeutronQuery::InterchainAccountAddress {
         owner_address: env.contract.address.to_string(),
         interchain_account_id,
         connection_id,
@@ -168,7 +172,7 @@ pub fn query_interchain_address(
 }
 
 pub fn query_interchain_address_contract(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
 ) -> NeutronResult<Binary> {
@@ -176,7 +180,7 @@ pub fn query_interchain_address_contract(
 }
 
 pub fn query_acknowledgement_result(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
     sequence_id: u64,
@@ -186,7 +190,7 @@ pub fn query_acknowledgement_result(
     Ok(to_binary(&res)?)
 }
 
-pub fn query_errors_queue(deps: Deps<InterchainQueries>) -> NeutronResult<Binary> {
+pub fn query_errors_queue(deps: Deps<NeutronQuery>) -> NeutronResult<Binary> {
     let res = read_errors_from_queue(deps.storage)?;
     Ok(to_binary(&res)?)
 }

--- a/contracts/neutron_interchain_txs/src/testing/tests.rs
+++ b/contracts/neutron_interchain_txs/src/testing/tests.rs
@@ -23,9 +23,9 @@ use cosmwasm_std::{
     OwnedDeps,
 };
 
-use neutron_sdk::bindings::query::InterchainQueries;
+use neutron_sdk::bindings::query::NeutronQuery;
 
-pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, InterchainQueries> {
+pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, NeutronQuery> {
     OwnedDeps {
         storage: MockStorage::default(),
         api: MockApi::default(),

--- a/contracts/neutron_validator_test/Cargo.toml
+++ b/contracts/neutron_validator_test/Cargo.toml
@@ -32,21 +32,19 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking"] }
-cw2 = "0.15.1"
+cosmwasm-std = "1.2.5"
+cw2 = "1.0.1"
 schemars = "0.8.10"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "0.4.1" }
-cw-storage-plus = { version = "0.14.0", features = ["iterator"]}
+cw-storage-plus = "1.0.1"
 cosmos-sdk-proto = { version = "0.14.0", default-features = false }
-neutron-sdk = { package = "neutron-sdk", default-features = false, version = "0.4.0" }
-base64 = "0.13.0"
+neutron-sdk = "0.5.0"
 protobuf = { version = "3", features = ["with-bytes"] }
 prost = "0.11"
 prost-types = "0.10"
 bech32 = "0.9.0"
 thiserror = { version = "1.0" }
-
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0", default-features = false }

--- a/contracts/price-feed/Cargo.toml
+++ b/contracts/price-feed/Cargo.toml
@@ -41,13 +41,11 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 [dependencies]
 
 cosmwasm-schema = "1.2.1"
-cosmwasm-std = "1.2.1"
+cosmwasm-std = "1.2.5"
 cosmwasm-storage = "1.1.3"
 cw-storage-plus = "1.0.1"
 cw2 = "1.0.1"
 cw-band = "0.1.1"
-neutron-sdk = { package = "neutron-sdk", default-features = false, version = "0.4.0" }
-base64 = "0.21.0"
 protobuf = { version = "3.2.0", features = ["with-bytes"] }
 prost = "0.11"
 prost-types = "0.11"

--- a/contracts/reflect/Cargo.toml
+++ b/contracts/reflect/Cargo.toml
@@ -33,10 +33,10 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0", features = ["staking"] }
-cw2 = "0.15.1"
+cosmwasm-std = "1.2.5"
+cw2 = "1.0.1"
 schemars = "0.8.10"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-neutron-sdk = { package = "neutron-sdk", default-features = false, version = "0.4.0" }
+neutron-sdk = "0.5.0"
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0", default-features = false }

--- a/contracts/tokenfactory/.cargo/config
+++ b/contracts/tokenfactory/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib --features backtraces"
+integration-test = "test --test integration"
+schema = "run --example schema"

--- a/contracts/tokenfactory/Cargo.toml
+++ b/contracts/tokenfactory/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "ibc_transfer"
+name = "tokenfactory"
 version = "0.1.0"
 edition = "2021"
 
 
 exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
+    # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+    "contract.wasm",
+    "hash.txt",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -34,13 +34,9 @@ library = []
 
 [dependencies]
 cosmwasm-std = "1.2.5"
-cw2 = "1.0.1"
-schemars = "0.8.10"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-serde-json-wasm = { version = "0.4.1" }
-cw-storage-plus = "1.0.1"
+serde = { version = "1.0.160", default-features = false, features = ["derive"] }
+schemars = "0.8.12"
 neutron-sdk = "0.5.0"
-protobuf = { version = "3.2.0", features = ["with-bytes"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0", default-features = false }
+cosmwasm-schema = { version = "1.2.4", default-features = false }

--- a/contracts/tokenfactory/README.md
+++ b/contracts/tokenfactory/README.md
@@ -1,0 +1,4 @@
+# TokenFactory
+
+This contract exposes all Token Factory wasm messages through its ExecuteMsg and QueryMsg APIs.
+It is used for testing Token Factory and its corresponding bindings.

--- a/contracts/tokenfactory/examples/schema.rs
+++ b/contracts/tokenfactory/examples/schema.rs
@@ -1,0 +1,29 @@
+// Copyright 2022 Neutron
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+use std::{env::current_dir, fs::create_dir_all};
+use tokenfactory::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(MigrateMsg), &out_dir);
+}

--- a/contracts/tokenfactory/schema/execute_msg.json
+++ b/contracts/tokenfactory/schema/execute_msg.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "create_denom"
+      ],
+      "properties": {
+        "create_denom": {
+          "type": "object",
+          "required": [
+            "subdenom"
+          ],
+          "properties": {
+            "subdenom": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "change_admin"
+      ],
+      "properties": {
+        "change_admin": {
+          "type": "object",
+          "required": [
+            "denom",
+            "new_admin_address"
+          ],
+          "properties": {
+            "denom": {
+              "type": "string"
+            },
+            "new_admin_address": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "mint_tokens"
+      ],
+      "properties": {
+        "mint_tokens": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "burn_tokens"
+      ],
+      "properties": {
+        "burn_tokens": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "send_tokens"
+      ],
+      "properties": {
+        "send_tokens": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom",
+            "recipient"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/tokenfactory/schema/instantiate_msg.json
+++ b/contracts/tokenfactory/schema/instantiate_msg.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object"
+}

--- a/contracts/tokenfactory/schema/migrate_msg.json
+++ b/contracts/tokenfactory/schema/migrate_msg.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "type": "object"
+}

--- a/contracts/tokenfactory/schema/query_msg.json
+++ b/contracts/tokenfactory/schema/query_msg.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "full_denom"
+      ],
+      "properties": {
+        "full_denom": {
+          "type": "object",
+          "required": [
+            "creator_addr",
+            "subdenom"
+          ],
+          "properties": {
+            "creator_addr": {
+              "type": "string"
+            },
+            "subdenom": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "denom_admin"
+      ],
+      "properties": {
+        "denom_admin": {
+          "type": "object",
+          "required": [
+            "subdenom"
+          ],
+          "properties": {
+            "subdenom": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/tokenfactory/src/contract.rs
+++ b/contracts/tokenfactory/src/contract.rs
@@ -1,0 +1,68 @@
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cosmwasm_std::{
+    coins, entry_point, to_binary, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    Response, StdResult,
+};
+use neutron_sdk::{
+    bindings::{msg::NeutronMsg, query::NeutronQuery},
+    query::token_factory::{query_denom_admin, query_full_denom},
+    NeutronResult,
+};
+
+#[entry_point]
+pub fn instantiate(
+    _deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> StdResult<Response> {
+    Ok(Response::new())
+}
+
+#[entry_point]
+pub fn execute(
+    _deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response<NeutronMsg>> {
+    let msg: CosmosMsg<NeutronMsg> = match msg {
+        ExecuteMsg::CreateDenom { subdenom } => NeutronMsg::submit_create_denom(subdenom).into(),
+        ExecuteMsg::ChangeAdmin {
+            denom,
+            new_admin_address,
+        } => NeutronMsg::submit_change_admin(denom, new_admin_address).into(),
+        ExecuteMsg::MintTokens { denom, amount } => {
+            NeutronMsg::submit_mint_tokens(denom, amount, env.contract.address).into()
+        }
+        ExecuteMsg::BurnTokens { denom, amount } => {
+            NeutronMsg::submit_burn_tokens(denom, amount).into()
+        }
+        ExecuteMsg::SendTokens {
+            recipient,
+            denom,
+            amount,
+        } => BankMsg::Send {
+            to_address: recipient,
+            amount: coins(amount.u128(), denom),
+        }
+        .into(),
+    };
+    Ok(Response::new().add_message(msg))
+}
+
+#[entry_point]
+pub fn query(deps: Deps<NeutronQuery>, _env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
+    Ok(match msg {
+        QueryMsg::FullDenom {
+            creator_addr,
+            subdenom,
+        } => to_binary(&query_full_denom(deps, creator_addr, subdenom)?)?,
+        QueryMsg::DenomAdmin { subdenom } => to_binary(&query_denom_admin(deps, subdenom)?)?,
+    })
+}
+
+#[entry_point]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    Ok(Response::new())
+}

--- a/contracts/tokenfactory/src/lib.rs
+++ b/contracts/tokenfactory/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2022 Neutron
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![warn(clippy::unwrap_used, clippy::expect_used)]
+
+pub mod contract;
+pub mod msg;

--- a/contracts/tokenfactory/src/msg.rs
+++ b/contracts/tokenfactory/src/msg.rs
@@ -1,0 +1,46 @@
+use cosmwasm_std::Uint128;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct InstantiateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    CreateDenom {
+        subdenom: String,
+    },
+    ChangeAdmin {
+        denom: String,
+        new_admin_address: String,
+    },
+    MintTokens {
+        denom: String,
+        amount: Uint128,
+    },
+    BurnTokens {
+        denom: String,
+        amount: Uint128,
+    },
+    SendTokens {
+        recipient: String,
+        denom: String,
+        amount: Uint128,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    FullDenom {
+        creator_addr: String,
+        subdenom: String,
+    },
+    DenomAdmin {
+        subdenom: String,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct MigrateMsg {}


### PR DESCRIPTION
This PR:
- upgrades all contracts to neutron-sdk v0.5.0
- adds `tokefactory.wasm` for use within integration tests

Merge with:
- https://github.com/neutron-org/neutron-tge-contracts/pull/43
- https://github.com/neutron-org/neutron-dao/pull/59
- https://github.com/neutron-org/neutron-integration-tests/pull/147

[[Assigned task](https://p2pvalidator.atlassian.net/browse/NTRN-431)] [[Recent test run](https://github.com/neutron-org/neutron-tests/actions/runs/4868744229)]