### PR TITLE
[NTRN-561] add mock submsg failures to interchain txs contract

### DIFF
--- a/contracts/neutron_interchain_txs/src/integration_tests_mock_handlers.rs
+++ b/contracts/neutron_interchain_txs/src/integration_tests_mock_handlers.rs
@@ -1,13 +1,32 @@
-use crate::storage::{IntegrationTestsSudoMock, INTEGRATION_TESTS_SUDO_MOCK};
+use crate::storage::{
+    IntegrationTestsSudoMock, IntegrationTestsSudoSubmsgMock, INTEGRATION_TESTS_SUDO_FAILURE_MOCK,
+    INTEGRATION_TESTS_SUDO_SUBMSG_FAILURE_MOCK,
+};
 use cosmwasm_std::{DepsMut, Response, StdResult};
 use neutron_sdk::bindings::msg::NeutronMsg;
 
 pub fn set_sudo_failure_mock(deps: DepsMut) -> StdResult<Response<NeutronMsg>> {
-    INTEGRATION_TESTS_SUDO_MOCK.save(deps.storage, &IntegrationTestsSudoMock::Enabled)?;
+    INTEGRATION_TESTS_SUDO_FAILURE_MOCK.save(deps.storage, &IntegrationTestsSudoMock::Enabled)?;
+    Ok(Response::default())
+}
+
+pub fn set_sudo_submsg_failure_mock(deps: DepsMut) -> StdResult<Response<NeutronMsg>> {
+    INTEGRATION_TESTS_SUDO_SUBMSG_FAILURE_MOCK
+        .save(deps.storage, &IntegrationTestsSudoSubmsgMock::Enabled)?;
+    Ok(Response::default())
+}
+
+pub fn set_sudo_submsg_failure_in_reply_mock(deps: DepsMut) -> StdResult<Response<NeutronMsg>> {
+    INTEGRATION_TESTS_SUDO_SUBMSG_FAILURE_MOCK.save(
+        deps.storage,
+        &IntegrationTestsSudoSubmsgMock::EnabledInReply,
+    )?;
     Ok(Response::default())
 }
 
 pub fn unset_sudo_failure_mock(deps: DepsMut) -> StdResult<Response<NeutronMsg>> {
-    INTEGRATION_TESTS_SUDO_MOCK.save(deps.storage, &IntegrationTestsSudoMock::Disabled)?;
+    INTEGRATION_TESTS_SUDO_FAILURE_MOCK.save(deps.storage, &IntegrationTestsSudoMock::Disabled)?;
+    INTEGRATION_TESTS_SUDO_SUBMSG_FAILURE_MOCK
+        .save(deps.storage, &IntegrationTestsSudoSubmsgMock::Disabled)?;
     Ok(Response::default())
 }

--- a/contracts/neutron_interchain_txs/src/msg.rs
+++ b/contracts/neutron_interchain_txs/src/msg.rs
@@ -57,10 +57,20 @@ pub enum ExecuteMsg {
     },
     CleanAckResults {},
     /// Used only in integration tests framework to simulate failures.
-    /// After executing this message, contract will fail, all of this happening
-    /// in sudo callback handler.
+    /// After executing this message, any sudo call to the contract will result in an error.
     IntegrationTestsSetSudoFailureMock {},
+    /// Used only in integration tests framework to simulate failures.
+    /// After executing this message, any sudo call to the contract will result in an submessage
+    /// processing error.
+    IntegrationTestsSetSudoSubmsgFailureMock {},
+    /// Used only in integration tests framework to simulate failures.
+    /// After executing this message, any sudo call to the contract will result in an submessage
+    /// reply processing error.
+    IntegrationTestsSetSudoSubmsgReplyFailureMock {},
     /// Used only in integration tests framework to simulate failures.
     /// After executing this message, contract will revert back to normal behaviour.
     IntegrationTestsUnsetSudoFailureMock {},
+    /// Used only in integration tests framework to simulate failures.
+    /// If the IntegrationTestsSetSudoSubmsgFailureMock has been called, this message will fail.
+    IntegrationTestsSudoSubmsg {},
 }

--- a/contracts/neutron_interchain_txs/src/msg.rs
+++ b/contracts/neutron_interchain_txs/src/msg.rs
@@ -1,3 +1,4 @@
+use crate::storage::AcknowledgementResult;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +19,8 @@ pub enum QueryMsg {
         interchain_account_id: String,
         sequence_id: u64,
     },
+    // this query returns all acknowledgements stored in the contract's state
+    AcknowledgementResults {},
     // this query returns non-critical errors list
     ErrorsQueue {},
 }
@@ -73,4 +76,11 @@ pub enum ExecuteMsg {
     /// Used only in integration tests framework to simulate failures.
     /// If the IntegrationTestsSetSudoSubmsgFailureMock has been called, this message will fail.
     IntegrationTestsSudoSubmsg {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct AcknowledgementResultsResponse {
+    pub ack_result: AcknowledgementResult,
+    pub port_id: String,
+    pub sequence_id: u64,
 }

--- a/contracts/neutron_interchain_txs/src/storage.rs
+++ b/contracts/neutron_interchain_txs/src/storage.rs
@@ -12,6 +12,7 @@ pub struct SudoPayload {
 }
 
 pub const SUDO_PAYLOAD_REPLY_ID: u64 = 1;
+pub const SUDO_FAILING_SUBMSG_REPLY_ID: u64 = 2;
 
 pub const IBC_FEE: Item<IbcFee> = Item::new("ibc_fee");
 pub const REPLY_ID_STORAGE: Item<Vec<u8>> = Item::new("reply_queue_id");
@@ -68,6 +69,7 @@ pub fn read_sudo_payload(
     channel_id: String,
     seq_id: u64,
 ) -> StdResult<SudoPayload> {
+    println!("read_sudo_payload: {:?}, {:?}", channel_id, seq_id);
     let data = SUDO_PAYLOAD.load(store, (channel_id, seq_id))?;
     from_binary(&Binary(data))
 }
@@ -78,15 +80,27 @@ pub fn save_sudo_payload(
     seq_id: u64,
     payload: SudoPayload,
 ) -> StdResult<()> {
+    println!("save_sudo_payload: {:?}, {:?}", channel_id, seq_id);
     SUDO_PAYLOAD.save(store, (channel_id, seq_id), &to_vec(&payload)?)
 }
 
-/// Used only in integration tests framework to simulate failures.
-pub const INTEGRATION_TESTS_SUDO_MOCK: Item<IntegrationTestsSudoMock> =
-    Item::new("integration_tests_sudo_mock");
+/// Used only in integration tests framework to simulate failures in sudo handler.
+pub const INTEGRATION_TESTS_SUDO_FAILURE_MOCK: Item<IntegrationTestsSudoMock> =
+    Item::new("integration_tests_sudo_failure_mock");
+/// Used only in integration tests framework to simulate failures in submessages created in
+/// sudo handler.
+pub const INTEGRATION_TESTS_SUDO_SUBMSG_FAILURE_MOCK: Item<IntegrationTestsSudoSubmsgMock> =
+    Item::new("integration_tests_sudo_submsg_failure_mock");
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub enum IntegrationTestsSudoMock {
     Enabled,
+    Disabled,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub enum IntegrationTestsSudoSubmsgMock {
+    Enabled,
+    EnabledInReply,
     Disabled,
 }

--- a/contracts/neutron_interchain_txs/src/storage.rs
+++ b/contracts/neutron_interchain_txs/src/storage.rs
@@ -69,7 +69,6 @@ pub fn read_sudo_payload(
     channel_id: String,
     seq_id: u64,
 ) -> StdResult<SudoPayload> {
-    println!("read_sudo_payload: {:?}, {:?}", channel_id, seq_id);
     let data = SUDO_PAYLOAD.load(store, (channel_id, seq_id))?;
     from_binary(&Binary(data))
 }
@@ -80,7 +79,6 @@ pub fn save_sudo_payload(
     seq_id: u64,
     payload: SudoPayload,
 ) -> StdResult<()> {
-    println!("save_sudo_payload: {:?}, {:?}", channel_id, seq_id);
     SUDO_PAYLOAD.save(store, (channel_id, seq_id), &to_vec(&payload)?)
 }
 

--- a/contracts/neutron_interchain_txs/src/testing/tests.rs
+++ b/contracts/neutron_interchain_txs/src/testing/tests.rs
@@ -10,20 +10,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
-
+use crate::contract::sudo;
+use crate::msg::ExecuteMsg;
 use crate::{
-    contract::query_errors_queue,
+    contract::{execute, query_errors_queue},
     storage::{add_error_to_queue, read_errors_from_queue, ERRORS_QUEUE},
 };
-
 use cosmwasm_std::{
     from_binary,
-    testing::{MockApi, MockQuerier, MockStorage},
-    OwnedDeps,
+    testing::{
+        mock_dependencies as cw_mock_dependencies, mock_env, mock_info, MockApi, MockQuerier,
+        MockStorage,
+    },
+    OwnedDeps, StdError,
 };
-
 use neutron_sdk::bindings::query::NeutronQuery;
+use neutron_sdk::sudo::msg::{RequestPacket, SudoMsg};
+use std::marker::PhantomData;
 
 pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, NeutronQuery> {
     OwnedDeps {
@@ -89,4 +92,36 @@ fn test_errors_queue() {
             (2u32.to_be_bytes().to_vec(), error)
         ]
     );
+}
+
+#[test]
+fn test_failure_mocks() {
+    let mut deps = cw_mock_dependencies();
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("", &[]),
+        ExecuteMsg::IntegrationTestsSetSudoFailureMock {},
+    )
+    .unwrap();
+
+    let src_port = String::from("src_port");
+    let src_channel = String::from("src_channel");
+    let dst_port = String::from("dst_port");
+    let dst_channel = String::from("dst_channel");
+    let sudo_resp = SudoMsg::Timeout {
+        request: RequestPacket {
+            sequence: Some(1u64),
+            source_port: Some(src_port),
+            source_channel: Some(src_channel),
+            destination_port: Some(dst_port),
+            destination_channel: Some(dst_channel),
+            data: None,
+            timeout_height: None,
+            timeout_timestamp: None,
+        },
+    };
+
+    let err = sudo(deps.as_mut(), mock_env(), sudo_resp).unwrap_err();
+    assert_eq!(err, StdError::generic_err("Integations test mock error"));
 }


### PR DESCRIPTION
**task:** https://p2pvalidator.atlassian.net/browse/NTRN-561

**related PRs:**
- https://github.com/neutron-org/neutron-integration-tests/pull/173

**this PR:**
- adds a number of additional exec msgs which set the contract to deliberately fail when handling sudo msg. The new failure mocks make it fail when 1) handling the sudo (not new); 2) when handling a submessage created in the sudo handler; 3) when handling the submessage reply.
- adds a query which returns all stored ack results.