### PR TITLE
Remove usage of deprecated data field in Neutron SDK ICTX helper for SDK 0.47 chains & update SDK 0.45 helper to backw compat NTRN-223

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 [[package]]
 name = "neutron-sdk"
 version = "0.8.0"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/v047-icq#cc9ea0e322780f73b3410c7885b70a2fdbd1ab8e"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/deprecated-data-field-ictx#9d7a83b14aa750d1534ba0ce51a88323913fb544"
 dependencies = [
  "bech32",
  "cosmos-sdk-proto 0.20.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ incremental = false
 overflow-checks = true
 
 [workspace.dependencies]
-neutron-sdk = { git = "https://github.com/neutron-org/neutron-sdk", branch = "feat/v047-icq" }
+neutron-sdk = { git = "https://github.com/neutron-org/neutron-sdk", branch = "feat/deprecated-data-field-ictx" }
 prost = "0.12.1"
 prost-types = "0.12.1"
 cosmos-sdk-proto = { version = "0.20.0", default-features = false }

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -626,7 +626,7 @@ fn sudo_response(
         let item_type = item.msg_type.as_str();
         item_types.push(item_type.to_string());
         match item_type {
-            "/cosmos.staking.v1beta1.MsgUndelegate" => {
+            "/cosmos.staking.v1beta1.MsgUndelegateResponse" => {
                 let out: MsgUndelegateResponse = decode_message_response(&item.data)?;
 
                 let completion_time = out.completion_time.or_else(|| {
@@ -639,7 +639,7 @@ fn sudo_response(
                 deps.api
                     .debug(format!("Undelegation completion time: {:?}", completion_time).as_str());
             }
-            "/cosmos.staking.v1beta1.MsgDelegate" => {
+            "/cosmos.staking.v1beta1.MsgDelegateResponse" => {
                 let _out: MsgDelegateResponse = decode_message_response(&item.data)?;
             }
             _ => {

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -37,9 +37,8 @@ use crate::msg::{
 use neutron_sdk::bindings::msg::{IbcFee, MsgSubmitTxResponse, NeutronMsg};
 use neutron_sdk::bindings::query::{NeutronQuery, QueryInterchainAccountAddressResponse};
 use neutron_sdk::bindings::types::ProtobufAny;
-use neutron_sdk::interchain_txs::helpers::{
-    decode_acknowledgement_response, decode_message_response, get_port_id,
-};
+use neutron_sdk::interchain_txs::helpers::{decode_message_response, get_port_id};
+use neutron_sdk::interchain_txs::v047::helpers::decode_acknowledgement_response;
 use neutron_sdk::sudo::msg::{RequestPacket, SudoMsg};
 use neutron_sdk::NeutronResult;
 
@@ -623,11 +622,11 @@ fn sudo_response(
 
     let mut item_types = vec![];
     for item in parsed_data {
-        let item_type = item.msg_type.as_str();
+        let item_type = item.type_url.as_str();
         item_types.push(item_type.to_string());
         match item_type {
             "/cosmos.staking.v1beta1.MsgUndelegateResponse" => {
-                let out: MsgUndelegateResponse = decode_message_response(&item.data)?;
+                let out: MsgUndelegateResponse = decode_message_response(&item.value)?;
 
                 let completion_time = out.completion_time.or_else(|| {
                     let error_msg = "WASMDEBUG: sudo_response: Recoverable error. Failed to get completion time";
@@ -640,7 +639,7 @@ fn sudo_response(
                     .debug(format!("Undelegation completion time: {:?}", completion_time).as_str());
             }
             "/cosmos.staking.v1beta1.MsgDelegateResponse" => {
-                let _out: MsgDelegateResponse = decode_message_response(&item.data)?;
+                let _out: MsgDelegateResponse = decode_message_response(&item.value)?;
             }
             _ => {
                 deps.api.debug(


### PR DESCRIPTION
[TASK](https://hadronlabs.atlassian.net/browse/NTRN-223)

related prs:
https://github.com/neutron-org/neutron-integration-tests/pull/271
https://github.com/neutron-org/neutron-sdk/pull/134