### PR TITLE
feat: pausable mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pausable"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-schema 2.0.4",
+ "cosmwasm-std 2.0.4",
+ "cw-storage-plus 2.0.0",
+ "cw2 2.0.0",
+ "neutron-sdk",
+ "schemars",
+ "serde",
+ "serde-json-wasm 1.0.1",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ compile:
 	    cosmwasm/workspace-optimizer:0.15.0
 
 check_contracts:
-	@cargo install cosmwasm-check --locked
+	@cargo install cosmwasm-check --locked --version 2.0.4
 	@cosmwasm-check --available-capabilities iterator,staking,stargate,neutron,cosmwasm_1_1,cosmwasm_1_2 artifacts/*.wasm
 
 build: schema clippy test fmt compile check_contracts

--- a/contracts/pausable/.cargo/config
+++ b/contracts/pausable/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --example pausable-schema"

--- a/contracts/pausable/Cargo.toml
+++ b/contracts/pausable/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "pausable"
+version = "0.1.0"
+edition = "2021"
+
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for quicker tests, cargo test --lib
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cw2 = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+serde-json-wasm = { workspace = true }
+neutron-sdk = { workspace = true }
+cw-storage-plus = { workspace = true }
+
+
+[dev-dependencies]
+cosmwasm-schema = { workspace = true }

--- a/contracts/pausable/README.md
+++ b/contracts/pausable/README.md
@@ -1,0 +1,5 @@
+# Description
+
+Simple contract for integration tests.
+
+Can be paused and unpaused by anybody

--- a/contracts/pausable/examples/pausable-schema.rs
+++ b/contracts/pausable/examples/pausable-schema.rs
@@ -1,0 +1,30 @@
+// Copyright 2022 Neutron
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use pausable::msg::{ExecuteMsg, InstantiateMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+}

--- a/contracts/pausable/schema/execute_msg.json
+++ b/contracts/pausable/schema/execute_msg.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "pause"
+      ],
+      "properties": {
+        "pause": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "unpause"
+      ],
+      "properties": {
+        "unpause": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/pausable/schema/instantiate_msg.json
+++ b/contracts/pausable/schema/instantiate_msg.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object"
+}

--- a/contracts/pausable/src/contract.rs
+++ b/contracts/pausable/src/contract.rs
@@ -19,7 +19,6 @@ pub fn instantiate(
     _info: MessageInfo,
     _msg: InstantiateMsg,
 ) -> StdResult<Response> {
-    deps.api.debug("WASMDEBUG: instantiate");
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
@@ -44,8 +43,6 @@ fn execute_update_pause(deps: DepsMut, paused: bool) -> StdResult<Response<Neutr
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _: Env, msg: QueryMsg) -> NeutronResult<Binary> {
-    deps.api
-        .debug(format!("WASMDEBUG: execute: received msg: {:?}", msg).as_str());
     match msg {
         QueryMsg::State {} => query_paused(deps),
     }

--- a/contracts/pausable/src/contract.rs
+++ b/contracts/pausable/src/contract.rs
@@ -1,0 +1,57 @@
+use crate::{
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    state::PAUSED,
+};
+use cosmwasm_std::{
+    entry_point, to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+};
+use cw2::set_contract_version;
+use neutron_sdk::bindings::msg::NeutronMsg;
+use neutron_sdk::NeutronResult;
+
+const CONTRACT_NAME: &str = concat!("crates.io:neutron-contracts__", env!("CARGO_PKG_NAME"));
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[entry_point]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> StdResult<Response> {
+    deps.api.debug("WASMDEBUG: instantiate");
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
+}
+
+#[entry_point]
+pub fn execute(
+    deps: DepsMut,
+    _: Env,
+    _: MessageInfo,
+    msg: ExecuteMsg,
+) -> StdResult<Response<NeutronMsg>> {
+    match msg {
+        ExecuteMsg::Pause {} => execute_update_pause(deps, true),
+        ExecuteMsg::Unpause {} => execute_update_pause(deps, false),
+    }
+}
+
+fn execute_update_pause(deps: DepsMut, paused: bool) -> StdResult<Response<NeutronMsg>> {
+    PAUSED.save(deps.storage, &paused)?;
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _: Env, msg: QueryMsg) -> NeutronResult<Binary> {
+    deps.api
+        .debug(format!("WASMDEBUG: execute: received msg: {:?}", msg).as_str());
+    match msg {
+        QueryMsg::State {} => query_paused(deps),
+    }
+}
+
+fn query_paused(deps: Deps) -> NeutronResult<Binary> {
+    let paused = PAUSED.load(deps.storage)?;
+    Ok(to_json_binary(&paused)?)
+}

--- a/contracts/pausable/src/lib.rs
+++ b/contracts/pausable/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 Neutron
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![warn(clippy::unwrap_used, clippy::expect_used)]
+
+pub mod contract;
+pub mod msg;
+pub mod state;

--- a/contracts/pausable/src/msg.rs
+++ b/contracts/pausable/src/msg.rs
@@ -1,0 +1,18 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct InstantiateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Pause {},
+    Unpause {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    State {},
+}

--- a/contracts/pausable/src/state.rs
+++ b/contracts/pausable/src/state.rs
@@ -1,0 +1,3 @@
+use cw_storage_plus::Item;
+
+pub const PAUSED: Item<bool> = Item::new("paused");


### PR DESCRIPTION
This mock is for testing security preproposal module in DAO. It has only two methods `Pause` and `Unpause` and a query - `State` which returns `bool` paused state

[Test run](https://github.com/neutron-org/neutron-tests/actions/runs/9894405327/job/27334538932)
[Integration tests](https://github.com/neutron-org/neutron-integration-tests/pull/327)
[Dao module](https://github.com/neutron-org/neutron-dao/pull/110)
[Neutronjsplus](https://github.com/neutron-org/neutronjsplus/pull/46)

[Task](https://hadronlabs.atlassian.net/browse/DRP-221)