### PR TITLE
feat: add possibility for unordered ica channels #ntrn-376

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "neutron-sdk"
 version = "0.11.0"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/remove-stargate#afe11ec1f30f189f0ea11c2fea3badd32aa1bbf9"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d3b24c51ab41a6e26516bdeedb51ca0ef89d9339"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "neutron-std-derive"
 version = "0.20.1"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/remove-stargate#afe11ec1f30f189f0ea11c2fea3badd32aa1bbf9"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d3b24c51ab41a6e26516bdeedb51ca0ef89d9339"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1380,7 +1380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "neutron-sdk"
 version = "0.11.0"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d3b24c51ab41a6e26516bdeedb51ca0ef89d9339"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#45b1e92069b8a0ab54097508de313f7c80c352f1"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "neutron-std-derive"
 version = "0.20.1"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d3b24c51ab41a6e26516bdeedb51ca0ef89d9339"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#45b1e92069b8a0ab54097508de313f7c80c352f1"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "neutron-sdk"
 version = "0.11.0"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#3d71caa8a27c0cb8b38661efeb9bb36ed4e33920"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d99b7c21d16de9d8967f2501a95980d52cc59df5"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "neutron-std-derive"
 version = "0.20.1"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#3d71caa8a27c0cb8b38661efeb9bb36ed4e33920"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d99b7c21d16de9d8967f2501a95980d52cc59df5"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "neutron-sdk"
 version = "0.11.0"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d99b7c21d16de9d8967f2501a95980d52cc59df5"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=main#8ef5964a964f592feab90389ef6d73bc270113b3"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
@@ -1155,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "neutron-std-derive"
 version = "0.20.1"
-source = "git+https://github.com/neutron-org/neutron-sdk?branch=feat/unordered-ica#d99b7c21d16de9d8967f2501a95980d52cc59df5"
+source = "git+https://github.com/neutron-org/neutron-sdk?branch=main#8ef5964a964f592feab90389ef6d73bc270113b3"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ incremental = false
 overflow-checks = true
 
 [workspace.dependencies]
-neutron-sdk = { package = "neutron-sdk", git = "https://github.com/neutron-org/neutron-sdk", branch = "feat/unordered-ica" }
+neutron-sdk = { package = "neutron-sdk", git = "https://github.com/neutron-org/neutron-sdk", branch = "main" }
 prost = "0.12.4"
 prost-types = "0.12.4"
 cosmos-sdk-proto = { version = "0.20.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ incremental = false
 overflow-checks = true
 
 [workspace.dependencies]
-neutron-sdk = { package = "neutron-sdk", git = "https://github.com/neutron-org/neutron-sdk", branch = "feat/remove-stargate" }
+neutron-sdk = { package = "neutron-sdk", git = "https://github.com/neutron-org/neutron-sdk", branch = "feat/unordered-ica" }
 prost = "0.12.4"
 prost-types = "0.12.4"
 cosmos-sdk-proto = { version = "0.20.0", default-features = false }

--- a/contracts/neutron_interchain_txs/schema/execute_msg.json
+++ b/contracts/neutron_interchain_txs/schema/execute_msg.json
@@ -20,6 +20,16 @@
             },
             "interchain_account_id": {
               "type": "string"
+            },
+            "ordering": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ChannelOrdering"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false
@@ -242,7 +252,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Used only in integration tests framework to simulate failures. After executing this message, any sudo call to the contract will result in an submessage processing error.",
+      "description": "Used only in integration tests framework to simulate failures. After executing this message, any sudo call to the contract will result in a submessage processing error.",
       "type": "object",
       "required": [
         "integration_tests_set_sudo_submsg_failure_mock"
@@ -256,7 +266,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Used only in integration tests framework to simulate failures. After executing this message, any sudo call to the contract will result in an submessage reply processing error.",
+      "description": "Used only in integration tests framework to simulate failures. After executing this message, any sudo call to the contract will result in a submessage reply processing error.",
       "type": "object",
       "required": [
         "integration_tests_set_sudo_submsg_reply_failure_mock"
@@ -299,6 +309,14 @@
     }
   ],
   "definitions": {
+    "ChannelOrdering": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "ORDER_ORDERED",
+        "ORDER_UNORDERED"
+      ]
+    },
     "IntegrationTestsSudoFailureMock": {
       "type": "string",
       "enum": [

--- a/contracts/neutron_interchain_txs/schema/execute_msg.json
+++ b/contracts/neutron_interchain_txs/schema/execute_msg.json
@@ -312,7 +312,6 @@
     "ChannelOrdering": {
       "type": "string",
       "enum": [
-        "NONE",
         "ORDER_ORDERED",
         "ORDER_UNORDERED"
       ]

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -34,7 +34,7 @@ use crate::integration_tests_mock_handlers::{
 use crate::msg::{
     AcknowledgementResultsResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
 };
-use neutron_sdk::bindings::msg::{IbcFee, NeutronMsg};
+use neutron_sdk::bindings::msg::{ChannelOrdering, IbcFee, NeutronMsg};
 use neutron_sdk::bindings::query::{NeutronQuery, QueryInterchainAccountAddressResponse};
 use neutron_sdk::bindings::types::ProtobufAny;
 use neutron_sdk::interchain_txs::helpers::{decode_message_response, get_port_id};
@@ -108,7 +108,8 @@ pub fn execute(
         ExecuteMsg::Register {
             connection_id,
             interchain_account_id,
-        } => execute_register_ica(deps, env, connection_id, interchain_account_id),
+            ordering,
+        } => execute_register_ica(deps, env, connection_id, interchain_account_id, ordering),
         ExecuteMsg::Delegate {
             validator,
             interchain_account_id,
@@ -307,12 +308,14 @@ fn execute_register_ica(
     env: Env,
     connection_id: String,
     interchain_account_id: String,
+    ordering: Option<ChannelOrdering>,
 ) -> StdResult<Response<NeutronMsg>> {
     let register_fee = REGISTER_FEE.load(deps.storage)?;
     let register = NeutronMsg::register_interchain_account(
         connection_id,
         interchain_account_id.clone(),
         Option::from(register_fee),
+        ordering,
     );
     let key = get_port_id(env.contract.address.as_str(), &interchain_account_id);
     INTERCHAIN_ACCOUNTS.save(deps.storage, key, &None)?;

--- a/contracts/neutron_interchain_txs/src/msg.rs
+++ b/contracts/neutron_interchain_txs/src/msg.rs
@@ -1,5 +1,6 @@
 use crate::storage::{AcknowledgementResult, IntegrationTestsSudoFailureMock};
 use cosmwasm_std::Uint128;
+use neutron_sdk::bindings::msg::ChannelOrdering;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +39,7 @@ pub enum ExecuteMsg {
     Register {
         connection_id: String,
         interchain_account_id: String,
+        ordering: Option<ChannelOrdering>,
     },
     SetFees {
         denom: String,
@@ -76,11 +78,11 @@ pub enum ExecuteMsg {
         state: IntegrationTestsSudoFailureMock,
     },
     /// Used only in integration tests framework to simulate failures.
-    /// After executing this message, any sudo call to the contract will result in an submessage
+    /// After executing this message, any sudo call to the contract will result in a submessage
     /// processing error.
     IntegrationTestsSetSudoSubmsgFailureMock {},
     /// Used only in integration tests framework to simulate failures.
-    /// After executing this message, any sudo call to the contract will result in an submessage
+    /// After executing this message, any sudo call to the contract will result in a submessage
     /// reply processing error.
     IntegrationTestsSetSudoSubmsgReplyFailureMock {},
     /// Used only in integration tests framework to simulate failures.

--- a/contracts/neutron_validator_test/src/contract.rs
+++ b/contracts/neutron_validator_test/src/contract.rs
@@ -32,7 +32,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use neutron_sdk::bindings::msg::{IbcFee, NeutronMsg};
+use neutron_sdk::bindings::msg::{ChannelOrdering, IbcFee, NeutronMsg};
 use neutron_sdk::bindings::query::{
     NeutronQuery, QueryInterchainAccountAddressResponse, QueryRegisteredQueryResponse,
 };
@@ -267,8 +267,12 @@ fn execute_register_ica(
     connection_id: String,
     interchain_account_id: String,
 ) -> NeutronResult<Response<NeutronMsg>> {
-    let register =
-        NeutronMsg::register_interchain_account(connection_id, interchain_account_id.clone(), None);
+    let register = NeutronMsg::register_interchain_account(
+        connection_id,
+        interchain_account_id.clone(),
+        None,
+        Some(ChannelOrdering::OrderOrdered),
+    );
     let key = get_port_id(env.contract.address.as_str(), &interchain_account_id);
     INTERCHAIN_ACCOUNTS.save(deps.storage, key, &None)?;
     Ok(Response::new().add_message(register))

--- a/contracts/reflect/schema/execute_msg.json
+++ b/contracts/reflect/schema/execute_msg.json
@@ -313,7 +313,6 @@
     "ChannelOrdering": {
       "type": "string",
       "enum": [
-        "NONE",
         "ORDER_ORDERED",
         "ORDER_UNORDERED"
       ]

--- a/contracts/reflect/schema/execute_msg.json
+++ b/contracts/reflect/schema/execute_msg.json
@@ -310,6 +310,14 @@
       },
       "additionalProperties": false
     },
+    "ChannelOrdering": {
+      "type": "string",
+      "enum": [
+        "NONE",
+        "ORDER_ORDERED",
+        "ORDER_UNORDERED"
+      ]
+    },
     "ClearAdminProposal": {
       "description": "Deprecated. SudoContractProposal defines the struct for clear admin proposal.",
       "deprecated": true,
@@ -1338,6 +1346,17 @@
                   "description": "**interchain_account_id** is an identifier of your new interchain account. Can be any string. This identifier allows contracts to have multiple interchain accounts on remote chains.",
                   "type": "string"
                 },
+                "ordering": {
+                  "description": "**ordering** is an order of channel. Can be ordered or unordered. Set to ordered if not specified.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/ChannelOrdering"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "register_fee": {
                   "description": "*register_fee** is a fees required to be payed to register interchain account",
                   "type": [
@@ -1473,7 +1492,7 @@
               ],
               "properties": {
                 "new_keys": {
-                  "description": "*new_keys** is the new query keys to retrive.",
+                  "description": "*new_keys** is the new query keys to retrieve.",
                   "type": [
                     "array",
                     "null"

--- a/contracts/reflect/src/contract.rs
+++ b/contracts/reflect/src/contract.rs
@@ -74,7 +74,14 @@ pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> StdResul
 pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> StdResult<Response> {
     match msg.id {
         REFLECT_REPLY_ID => {
-            Ok(Response::default().set_data(msg.result.unwrap().msg_responses[0].clone().value))
+            let res = Response::default();
+
+            let msg_responses = msg.result.unwrap().msg_responses;
+            if msg_responses.is_empty() {
+                Ok(res)
+            } else {
+                Ok(res.set_data(msg_responses[0].clone().value))
+            }
         }
         _ => {
             unimplemented!()


### PR DESCRIPTION
https://hadronlabs.atlassian.net/browse/NTRN-376


Now ICA accounts can be with unordered channels.
They do not close after timeout. And messages be delivered in random order.

PR's:
- https://github.com/neutron-org/neutron/pull/656
- https://github.com/neutron-org/neutron-sdk/pull/160
- https://github.com/neutron-org/neutron-dev-contracts/pull/62
- https://github.com/neutron-org/neutron-integration-tests/pull/337